### PR TITLE
Add TCP console support in bhyve

### DIFF
--- a/docs/drvbhyve.rst
+++ b/docs/drvbhyve.rst
@@ -216,6 +216,19 @@ enabled by adding the following to the domain XML ( :since:`Since 1.2.4` ):
    </devices>
    ...
 
+Alternatively the serial console can be exposed on a TCP port using the
+same XML syntax as for QEMU:
+
+::
+
+   ...
+   <devices>
+     <serial type="tcp">
+       <source mode='bind' host='192.168.0.2' service='4444'/>
+     </serial>
+   </devices>
+   ...
+
 Make sure to load the ``nmdm`` kernel module if you plan to use that.
 
 Then ``virsh console`` command can be used to connect to the text console of a

--- a/src/bhyve/bhyve_command.c
+++ b/src/bhyve/bhyve_command.c
@@ -166,9 +166,10 @@ bhyveBuildConsoleArgStr(const virDomainDef *def, virCommand *cmd)
 
     chr = def->serials[0];
 
-    if (chr->source->type != VIR_DOMAIN_CHR_TYPE_NMDM) {
+    if (chr->source->type != VIR_DOMAIN_CHR_TYPE_NMDM &&
+        chr->source->type != VIR_DOMAIN_CHR_TYPE_TCP) {
         virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
-                       _("only nmdm console types are supported"));
+                       _("only nmdm or tcp console types are supported"));
         return -1;
     }
 
@@ -180,8 +181,32 @@ bhyveBuildConsoleArgStr(const virDomainDef *def, virCommand *cmd)
     }
 
     virCommandAddArg(cmd, "-l");
-    virCommandAddArgFormat(cmd, "com%d,%s",
-                           chr->target.port + 1, chr->source->data.file.path);
+
+    if (chr->source->type == VIR_DOMAIN_CHR_TYPE_NMDM) {
+        virCommandAddArgFormat(cmd, "com%d,%s",
+                               chr->target.port + 1,
+                               chr->source->data.file.path);
+    } else {
+        const char *host = chr->source->data.tcp.host;
+        const char *service = chr->source->data.tcp.service;
+        bool escapeAddr;
+
+        if (!host || !service) {
+            virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
+                           _("missing host or service for tcp console"));
+            return -1;
+        }
+
+        escapeAddr = strchr(host, ':') != NULL;
+        if (escapeAddr)
+            virCommandAddArgFormat(cmd, "com%d,tcp=[%s]:%s",
+                                   chr->target.port + 1,
+                                   host, service);
+        else
+            virCommandAddArgFormat(cmd, "com%d,tcp=%s:%s",
+                                   chr->target.port + 1,
+                                   host, service);
+    }
 
     return 0;
 }

--- a/src/bhyve/bhyve_parse_command.c
+++ b/src/bhyve/bhyve_parse_command.c
@@ -275,36 +275,53 @@ bhyveParseBhyveLPCArg(virDomainDef *def,
         if (!(chr = virDomainChrDefNew(NULL)))
             goto error;
 
-        chr->source->type = VIR_DOMAIN_CHR_TYPE_NMDM;
         chr->source->data.nmdm.master = NULL;
         chr->source->data.nmdm.slave = NULL;
+        chr->source->data.tcp.host = NULL;
+        chr->source->data.tcp.service = NULL;
+        chr->source->data.tcp.listen = true;
+        chr->source->data.tcp.protocol = VIR_DOMAIN_CHR_TCP_PROTOCOL_RAW;
         chr->deviceType = VIR_DOMAIN_CHR_DEVICE_TYPE_SERIAL;
 
-        if (!STRPREFIX(param, "/dev/nmdm")) {
+        if (STRPREFIX(param, "/dev/nmdm")) {
+            chr->source->type = VIR_DOMAIN_CHR_TYPE_NMDM;
+            chr->source->data.nmdm.master = g_strdup(param);
+            chr->source->data.nmdm.slave = g_strdup(chr->source->data.file.path);
+
+            /* If the last character of the master is 'A', the slave will be 'B'
+             * and vice versa */
+            last = strlen(chr->source->data.nmdm.master) - 1;
+            switch (chr->source->data.file.path[last]) {
+                case 'A':
+                    chr->source->data.nmdm.slave[last] = 'B';
+                    break;
+                case 'B':
+                    chr->source->data.nmdm.slave[last] = 'A';
+                    break;
+                default:
+                    virReportError(VIR_ERR_OPERATION_FAILED,
+                                   _("Failed to set slave for %1$s: last letter not 'A' or 'B'"),
+                                   NULLSTR(chr->source->data.nmdm.master));
+                    goto error;
+            }
+        } else if (STRPREFIX(param, "tcp=")) {
+            char *sep;
+            chr->source->type = VIR_DOMAIN_CHR_TYPE_TCP;
+            param += strlen("tcp=");
+            if (!(sep = strchr(param, ':')))
+                goto error;
+            *sep = '\0';
+            if (sep != param)
+                chr->source->data.tcp.host = g_strdup(param);
+            else
+                chr->source->data.tcp.host = g_strdup("127.0.0.1");
+            param = sep + 1;
+            chr->source->data.tcp.service = g_strdup(param);
+        } else {
             virReportError(VIR_ERR_OPERATION_FAILED,
-                           _("Failed to set com port %1$s: does not start with '/dev/nmdm'."),
+                           _("Failed to set com port %1$s: unsupported source"),
                            type);
-                goto error;
-        }
-
-        chr->source->data.nmdm.master = g_strdup(param);
-        chr->source->data.nmdm.slave = g_strdup(chr->source->data.file.path);
-
-        /* If the last character of the master is 'A', the slave will be 'B'
-         * and vice versa */
-        last = strlen(chr->source->data.nmdm.master) - 1;
-        switch (chr->source->data.file.path[last]) {
-            case 'A':
-                chr->source->data.nmdm.slave[last] = 'B';
-                break;
-            case 'B':
-                chr->source->data.nmdm.slave[last] = 'A';
-                break;
-            default:
-                virReportError(VIR_ERR_OPERATION_FAILED,
-                               _("Failed to set slave for %1$s: last letter not 'A' or 'B'"),
-                               NULLSTR(chr->source->data.nmdm.master));
-                goto error;
+            goto error;
         }
 
         switch (type[3]-'0') {


### PR DESCRIPTION
## Summary
- extend bhyve backend to support TCP serial consoles
- allow parsing of `tcp=host:port` when converting from native command line
- document TCP console usage for the bhyve driver

## Testing
- `meson setup build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840428436248322b7ecaceeb3f9b16c