### PR TITLE
feat: Add TCP serial console redirection for bhyve

### DIFF
--- a/docs/drvbhyve.rst
+++ b/docs/drvbhyve.rst
@@ -246,6 +246,62 @@ serial device) is:
 
    cu -l /dev/nmdm0B
 
+Connecting to a guest console via TCP
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:since:`Since X.Y.Z` (NB: Replace X.Y.Z with the actual libvirt version), guest serial
+consoles can also be redirected to a TCP port. This allows connecting to the
+guest's serial console over the network. The bhyve driver uses the same XML
+syntax as the QEMU driver for this feature.
+
+To configure a serial port to listen on a specific IP address and port (server mode):
+
+::
+
+   ...
+   <devices>
+     <serial type='tcp'>
+       <source mode='bind' host='192.168.0.2' service='4444'/>
+       <protocol type='raw'/> <!-- 'telnet' is also possible, but 'raw' is common -->
+       <target port='0'/> <!-- com1 -->
+       <alias name='serial0'/>
+     </serial>
+     <console type='pty'> <!-- Optional: if you still want a PTY console -->
+       <target type='serial' port='0'/>
+     </console>
+   </devices>
+   ...
+
+This will make bhyve start a TCP server listening on IP `192.168.0.2` and port
+`4444`. You can then connect to this address and port using a tool like
+`telnet` or `nc` to access the guest's serial console. Libvirt will generate
+the bhyve command-line argument: ``-l com1,tcp=192.168.0.2:4444,server``.
+
+To configure a serial port to connect to a remote TCP server (client mode):
+
+::
+
+   ...
+   <devices>
+     <serial type='tcp'>
+       <source mode='connect' host='192.168.0.2' service='4444'/>
+       <protocol type='raw'/>
+       <target port='1'/> <!-- com2 -->
+       <alias name='serial1'/>
+     </serial>
+   </devices>
+   ...
+
+In this case, bhyve will attempt to connect to a TCP server at `192.168.0.2`
+on port `4444`. Libvirt generates the bhyve command-line argument:
+``-l com2,tcp=192.168.0.2:4444``. If the `server` option is omitted in the
+bhyve command, it defaults to client (connect) mode.
+
+This feature is useful for remote console access or for integrating with
+other tools that can provide or consume serial data over TCP. Note that
+only ``com1`` (target port 0) and ``com2`` (target port 1) are generally
+supported by bhyve for serial devices.
+
 Converting from domain XML to Bhyve args
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/bhyve/bhyve_capabilities.c
+++ b/src/bhyve/bhyve_capabilities.c
@@ -349,6 +349,17 @@ bhyveProbeCapsVirtioRnd(unsigned int *caps, char *binary)
 }
 
 
+static int
+bhyveProbeCapsSerialTCP(unsigned int *caps, char *binary)
+{
+    return bhyveProbeCapsDeviceHelper(caps, binary,
+                                      "-l",
+                                      "com1,tcp=127.0.0.1:1",
+                                      "invalid lpc device configuration 'tcp'",
+                                      BHYVE_CAP_SERIAL_TCP);
+}
+
+
 int
 virBhyveProbeCaps(unsigned int *caps)
 {
@@ -387,6 +398,9 @@ virBhyveProbeCaps(unsigned int *caps)
         goto out;
 
     if ((ret = bhyveProbeCapsVirtioRnd(caps, binary)))
+        goto out;
+
+    if ((ret = bhyveProbeCapsSerialTCP(caps, binary)))
         goto out;
 
  out:

--- a/src/bhyve/bhyve_capabilities.h
+++ b/src/bhyve/bhyve_capabilities.h
@@ -54,6 +54,7 @@ typedef enum {
     BHYVE_CAP_VNC_PASSWORD = 1 << 8,
     BHYVE_CAP_VIRTIO_9P = 1 << 9,
     BHYVE_CAP_VIRTIO_RND = 1 << 10,
+    BHYVE_CAP_SERIAL_TCP = 1 << 11,
 } virBhyveCapsFlags;
 
 int virBhyveProbeGrubCaps(virBhyveGrubCapsFlags *caps);

--- a/src/bhyve/bhyve_command.c
+++ b/src/bhyve/bhyve_command.c
@@ -157,31 +157,61 @@ bhyveBuildNetArgStr(const virDomainDef *def,
 }
 
 static int
-bhyveBuildConsoleArgStr(const virDomainDef *def, virCommand *cmd)
+bhyveBuildConsoleArgStr(const virDomainDef *def,
+                          virCommand *cmd,
+                          struct _bhyveConn *driver)
 {
     virDomainChrDef *chr = NULL;
+    unsigned int capabilities;
 
-    if (!def->nserials)
+    if (def->nserials == 0)
         return 0;
 
-    chr = def->serials[0];
-
-    if (chr->source->type != VIR_DOMAIN_CHR_TYPE_NMDM) {
+    if (def->nserials > 1) {
         virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
-                       _("only nmdm console types are supported"));
+                       _("bhyve only supports one serial port"));
         return -1;
     }
 
+    chr = def->serials[0];
+
     /* bhyve supports only two ports: com1 and com2 */
-    if (chr->target.port > 2) {
+    if (chr->target.port >= 2) { /* target.port is 0-indexed, so port 0 and 1 are valid */
         virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
                        _("only two serial ports are supported"));
         return -1;
     }
 
     virCommandAddArg(cmd, "-l");
-    virCommandAddArgFormat(cmd, "com%d,%s",
-                           chr->target.port + 1, chr->source->data.file.path);
+
+    switch (chr->source->type) {
+    case VIR_DOMAIN_CHR_TYPE_NMDM:
+        virCommandAddArgFormat(cmd, "com%d,%s",
+                                chr->target.port + 1, chr->source->data.file.path);
+        break;
+    case VIR_DOMAIN_CHR_TYPE_TCP:
+        capabilities = bhyveDriverGetBhyveCaps(driver);
+        if (!(capabilities & BHYVE_CAP_SERIAL_TCP)) {
+            virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                           _("bhyve version does not support TCP serial console redirection"));
+            return -1;
+        }
+        if (!chr->source->data.tcp.host || !chr->source->data.tcp.service) {
+            virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                           _("TCP serial device needs host and port"));
+            return -1;
+        }
+        virCommandAddArgFormat(cmd, "com%d,tcp=%s:%s%s",
+                               chr->target.port + 1, chr->source->data.tcp.host,
+                               chr->source->data.tcp.service,
+                               chr->source->data.tcp.listen ? ",server" : "");
+        break;
+    default:
+        virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
+                       _("Unsupported console type: %s"),
+                       virDomainChrTypeToString(chr->source->type));
+        return -1;
+    }
 
     return 0;
 }
@@ -860,7 +890,7 @@ virBhyveProcessBuildBhyveCmd(struct _bhyveConn *driver, virDomainDef *def,
             return NULL;
     }
 
-    if (bhyveBuildConsoleArgStr(def, cmd) < 0)
+    if (bhyveBuildConsoleArgStr(def, cmd, driver) < 0)
         return NULL;
 
     for (i = 0; i < def->nrngs; i++)

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-client.args
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-client.args
@@ -1,0 +1,1 @@
+bhyve -c 1 -m 800 -A -H -P -s 0:0,hostbridge -l com2,tcp=10.0.0.1:5678 bhyve-test-tcp-client

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-client.xml
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-client.xml
@@ -1,0 +1,19 @@
+<domain type='bhyve'>
+  <name>bhyve-test-tcp-client</name>
+  <uuid>c7a5fdbd-edaf-9455-926a-d65c16db180A</uuid>
+  <memory unit='KiB'>819200</memory>
+  <currentMemory unit='KiB'>819200</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.1'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/sbin/bhyve</emulator>
+    <serial type='tcp'>
+      <source mode='connect' host='10.0.0.1' service='5678'/>
+      <protocol type='raw'/>
+      <target port='1'/> <!-- com2 -->
+    </serial>
+  </devices>
+</domain>

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-invalid-port.xml
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-invalid-port.xml
@@ -1,0 +1,18 @@
+<domain type='bhyve'>
+  <name>bhyve-test-invalid-tcp-port</name>
+  <uuid>c7a5fdbd-edaf-9455-926a-d65c16db180D</uuid>
+  <memory unit='KiB'>819200</memory>
+  <currentMemory unit='KiB'>819200</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.1'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/sbin/bhyve</emulator>
+    <serial type='tcp'>
+      <source mode='bind' host='192.168.1.100'/> <!-- Service/port is missing -->
+      <target port='0'/>
+    </serial>
+  </devices>
+</domain>

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-invalid.xml
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-invalid.xml
@@ -1,0 +1,18 @@
+<domain type='bhyve'>
+  <name>bhyve-test-invalid-tcp</name>
+  <uuid>c7a5fdbd-edaf-9455-926a-d65c16db180C</uuid>
+  <memory unit='KiB'>819200</memory>
+  <currentMemory unit='KiB'>819200</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.1'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/sbin/bhyve</emulator>
+    <serial type='tcp'>
+      <source mode='bind' service='1234'/> <!-- Host is missing -->
+      <target port='0'/>
+    </serial>
+  </devices>
+</domain>

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-nocap.xml
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-nocap.xml
@@ -1,0 +1,19 @@
+<domain type='bhyve'>
+  <name>bhyve-test-tcp-nocap</name>
+  <uuid>c7a5fdbd-edaf-9455-926a-d65c16db180B</uuid>
+  <memory unit='KiB'>819200</memory>
+  <currentMemory unit='KiB'>819200</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.1'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/sbin/bhyve</emulator>
+    <serial type='tcp'>
+      <source mode='bind' host='192.168.1.100' service='1234'/>
+      <protocol type='raw'/>
+      <target port='0'/>
+    </serial>
+  </devices>
+</domain>

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-server.args
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-server.args
@@ -1,0 +1,1 @@
+bhyve -c 1 -m 800 -A -H -P -s 0:0,hostbridge -l com1,tcp=192.168.1.100:1234,server bhyve-test-tcp-server

--- a/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-server.xml
+++ b/tests/bhyvexml2argvdata/bhyvexml2argv-serial-tcp-server.xml
@@ -1,0 +1,22 @@
+<domain type='bhyve'>
+  <name>bhyve-test-tcp-server</name>
+  <uuid>c7a5fdbd-edaf-9455-926a-d65c16db1809</uuid>
+  <memory unit='KiB'>819200</memory>
+  <currentMemory unit='KiB'>819200</currentMemory>
+  <vcpu placement='static'>1</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-i440fx-2.1'>hvm</type>
+    <boot dev='hd'/>
+  </os>
+  <devices>
+    <emulator>/usr/sbin/bhyve</emulator>
+    <serial type='tcp'>
+      <source mode='bind' host='192.168.1.100' service='1234'/>
+      <protocol type='raw'/> <!-- bhyve doesn't care about telnet/raw, but good to have for qemu compat -->
+      <target port='0'/> <!-- com1 -->
+    </serial>
+    <console type='pty'>
+      <target type='serial' port='0'/>
+    </console>
+  </devices>
+</domain>

--- a/tests/bhyvexml2argvtest.c
+++ b/tests/bhyvexml2argvtest.c
@@ -193,7 +193,8 @@ mymain(void)
                        BHYVE_CAP_NET_E1000 | BHYVE_CAP_LPC_BOOTROM | \
                        BHYVE_CAP_FBUF | BHYVE_CAP_XHCI | \
                        BHYVE_CAP_CPUTOPOLOGY | BHYVE_CAP_SOUND_HDA | \
-                       BHYVE_CAP_VNC_PASSWORD | BHYVE_CAP_VIRTIO_9P;
+                       BHYVE_CAP_VNC_PASSWORD | BHYVE_CAP_VIRTIO_9P | \
+                       BHYVE_CAP_SERIAL_TCP;
 
     DO_TEST("base");
     DO_TEST("wired");
@@ -255,6 +256,14 @@ mymain(void)
     driver.bhyvecaps &= ~BHYVE_CAP_VIRTIO_RND;
     DO_TEST_FAILURE("virtio-rnd");
 
+    /* Serial TCP tests */
+    DO_TEST("serial-tcp-server");
+    DO_TEST("serial-tcp-client");
+    DO_TEST_FULL("serial-tcp-invalid", FLAG_EXPECT_FAILURE);
+    DO_TEST_FULL("serial-tcp-invalid-port", FLAG_EXPECT_FAILURE);
+    if (virTestRun("BHYVE XML-2-ARGV serial-tcp-nocap", testCompareXMLToArgvSerialTcpNoCap, NULL) < 0)
+        ret = -1;
+
     /* Address allocation tests */
     DO_TEST("addr-single-sata-disk");
     DO_TEST("addr-multiple-sata-disks");
@@ -308,6 +317,30 @@ mymain(void)
     virObjectUnref(driver.config);
 
     return ret == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
+}
+
+static int
+testCompareXMLToArgvSerialTcpNoCap(const void *data G_GNUC_UNUSED)
+{
+    const struct testInfo info = { "serial-tcp-nocap", FLAG_EXPECT_FAILURE };
+    g_autofree char *xml = NULL;
+    g_autofree char *args = NULL;
+    g_autofree char *ldargs = NULL;
+    g_autofree char *dmargs = NULL;
+    unsigned int oldcaps;
+    int ret;
+
+    xml = g_strdup_printf("%s/bhyvexml2argvdata/bhyvexml2argv-%s.xml",
+                          abs_srcdir, info.name);
+
+    oldcaps = driver.bhyvecaps;
+    driver.bhyvecaps &= ~BHYVE_CAP_SERIAL_TCP;
+
+    ret = testCompareXMLToArgvFiles(xml, args, ldargs, dmargs, info.flags);
+
+    driver.bhyvecaps = oldcaps;
+
+    return ret;
 }
 
 VIR_TEST_MAIN_PRELOAD(mymain, VIR_TEST_MOCK("bhyvexml2argv"))


### PR DESCRIPTION
This commit updates the bhyve driver to support redirecting the guest serial console to a TCP port, similar to QEMU's -serial tcp:host:port functionality.

The bhyve hypervisor supports this via the `-l comX,tcp=IP:PORT[,server]` command-line argument.

Changes include:
-   Leveraging the existing QEMU-compatible XML parsing for TCP
    character devices in `src/conf/domain_conf.c`. The XML syntax
    for `<serial type='tcp'>` with `<source mode='bind|connect' ...>`
    is now applicable to bhyve.
-   Modifying `src/bhyve/bhyve_command.c` (in `bhyveBuildConsoleArgStr`)
    to generate the correct bhyve command-line arguments when TCP
    serial redirection is configured.
-   Adding a new capability flag `BHYVE_CAP_SERIAL_TCP` in
    `src/bhyve/bhyve_capabilities.c` and `.h` to detect if the
    installed bhyve binary supports this feature. The command generation
    logic now checks this flag.
-   Adding comprehensive tests in `tests/bhyvexml2argvdata/` and
    `tests/bhyvexml2argvtest.c` to cover server mode, client mode,
    invalid configurations, and behavior when the capability is absent.
-   Updating `docs/drvbhyve.rst` to document the new feature and its
    XML configuration.